### PR TITLE
fix: modify revoke tests to ensure we are not using dates in weekends

### DIFF
--- a/t/integration/leave_request/leave_request_revoke.js
+++ b/t/integration/leave_request/leave_request_revoke.js
@@ -20,7 +20,9 @@ const
   config                 = require('../../lib/config'),
   application_host       = config.get_application_host(),
   department_edit_form_id = '#department_edit_form',
-  currentYear = moment.utc().year();
+  currentYear = moment.utc().year(),
+  monday = moment().year(currentYear).month('May').day(15).startOf('isoWeek'),
+  tuesday = moment(monday).add(1, 'd');
 
 /*
  *  Scenario to check:
@@ -151,7 +153,7 @@ describe('Revoke leave request', function(){
 
   it("Open calendar page", function(done){
     open_page_func({
-      url    : application_host + 'calendar/?show_full_year=1',
+      url    : application_host + `calendar/?year=${currentYear}&show_full_year=1`,
       driver : driver,
     })
     .then(function(){ done() });
@@ -186,10 +188,10 @@ describe('Revoke leave request', function(){
             value           : "2",
           },{
             selector : 'input#from',
-            value : `${currentYear}-05-15`,
+            value : monday.format('YYYY-MM-DD'),
           },{
             selector : 'input#to',
-            value : `${currentYear}-05-16`,
+            value : tuesday.format('YYYY-MM-DD'),
           }],
           message : /New leave request was added/,
         })
@@ -200,8 +202,8 @@ describe('Revoke leave request', function(){
   it("Check that all days are marked as pended", function(done){
     check_booking_func({
       driver         : driver,
-      full_days      : [moment.utc(`${currentYear}-05-16`)],
-      halfs_1st_days : [moment.utc(`${currentYear}-05-15`)],
+      full_days      : [tuesday],
+      halfs_1st_days : [monday],
       type           : 'pended',
     })
     .then(function(){ done() });

--- a/t/integration/leave_request/leave_request_revoke_by_admin.js
+++ b/t/integration/leave_request/leave_request_revoke_by_admin.js
@@ -18,7 +18,9 @@ var test             = require('selenium-webdriver/testing'),
     add_new_user_func      = require('../../lib/add_new_user'),
     config                 = require('../../lib/config'),
     application_host       = config.get_application_host(),
-    currentYear = moment.utc().year();
+    currentYear = moment.utc().year(),
+    monday = moment().year(currentYear).month('May').day(15).startOf('isoWeek'),
+    tuesday = moment(monday).add(1, 'd');
 
 /*
  *  Scenario to check:
@@ -81,7 +83,7 @@ describe('Revoke leave request by Admin', function(){
 
   it("Open calendar page", function(done){
     open_page_func({
-      url    : application_host + 'calendar/?show_full_year=1',
+      url    : application_host + `calendar/?year=${currentYear}&show_full_year=1`,
       driver : driver,
     })
     .then(function(){ done() });
@@ -114,10 +116,10 @@ describe('Revoke leave request by Admin', function(){
             value           : "2",
           },{
             selector : 'input#from',
-            value : `${currentYear}-05-15`,
+            value : monday.format('YYYY-MM-DD'),
           },{
             selector : 'input#to',
-            value : `${currentYear}-05-16`,
+            value : tuesday.format('YYYY-MM-DD'),
           }],
           message : /New leave request was added/,
         })
@@ -128,8 +130,8 @@ describe('Revoke leave request by Admin', function(){
   it("Check that all days are marked as pended", function(done){
     check_booking_func({
       driver         : driver,
-      full_days      : [moment.utc(`${currentYear}-05-16`)],
-      halfs_1st_days : [moment.utc(`${currentYear}-05-15`)],
+      full_days      : [tuesday],
+      halfs_1st_days : [monday],
       type           : 'pended',
     })
     .then(function(){ done() });


### PR DESCRIPTION
This fixes #95 by making sure we do not use weekend dates inside the test (_2016-05-15_ was a Sunday, which created the issue when using the year 2016).