### PR TITLE
Change footer to get current year and also update LICENSE to 2020.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.swm
 node_modules/
 *.sqlite
+package-lock.json
+yarn.lock

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2017 TimeOff.Management
+Copyright (c) 2015-2020 TimeOff.Management
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/model/company/exporter/summary.js
+++ b/lib/model/company/exporter/summary.js
@@ -44,7 +44,7 @@ class CompanySummary {
 
     // Put headers
     results.push([
-      'Ddepartment', 'Lastname', 'Name', 'Email address',
+      'Department', 'Lastname', 'Name', 'Email address',
       'Type of absence', 'Started at', 'Date type', 'Ended at', 'Date type'
     ]);
 

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -33,6 +33,9 @@
       <script src="{{this}}"></script>
     {{~/each~}}
 
+    <!-- get current year for footer -->
+    <script>document.getElementById('current-year').appendChild(document.createTextNode(new Date().getFullYear()))</script>
+
     {{~# is_ga_analitics_on ~}}
       <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/views/partials/footer.hbs
+++ b/views/partials/footer.hbs
@@ -6,7 +6,7 @@
 
 <footer class="footer custom-footer">
   <p>
-    <span class="pull-left">© <a href="http://timeoff.management">TimeOff.management</a> 2014-2019</span>
+    <span class="pull-left">© <a href="http://timeoff.management">TimeOff.management</a> 2014-2020</span>
     <span class="pull-right">
       <a href="https://github.com/timeoff-management/application"><i class="fa fa-github fa-lg"></i></a>
       <a href="https://twitter.com/FreeTimeOffApp"><i class="fa fa-twitter fa-lg"></i></a>

--- a/views/partials/footer.hbs
+++ b/views/partials/footer.hbs
@@ -6,7 +6,7 @@
 
 <footer class="footer custom-footer">
   <p>
-    <span class="pull-left">© <a href="http://timeoff.management">TimeOff.management</a> 2014-2020</span>
+    <span class="pull-left">© <a href="http://timeoff.management">TimeOff.management</a> 2014-<span id="current-year"></span></span>
     <span class="pull-right">
       <a href="https://github.com/timeoff-management/application"><i class="fa fa-github fa-lg"></i></a>
       <a href="https://twitter.com/FreeTimeOffApp"><i class="fa fa-twitter fa-lg"></i></a>


### PR DESCRIPTION
Previously, the footer's defined year was static in the footer partial.

I have added a simple JS script into the main view and altered the footer partial to make this dynamic, therefore the footer will no longer show an outdated year.

I have also updated the license file to 2020.