### PR TITLE
Fix footer links

### DIFF
--- a/views/partials/footer.hbs
+++ b/views/partials/footer.hbs
@@ -8,8 +8,8 @@
   <p>
     <span class="pull-left">© <a href="http://timeoff.management">TimeOff.management</a> 2014-2019</span>
     <span class="pull-right">
-      <a href="https://github.com/timeoff-management/application"><i class="fa fa-github fa-lg"></i></a>
-      <a href="https://twitter.com/FreeTimeOffApp"><i class="fa fa-twitter fa-lg"></i></a>
+      <a href="//github.com/timeoff-management/application"><i class="fa fa-github fa-lg"></i></a>
+      <a href="//twitter.com/FreeTimeOffApp"><i class="fa fa-twitter fa-lg"></i></a>
       <a href="mailto:pavlo@timeoff.management"><i class="fa fa-envelope fa-lg"></i></a>
     </span>
   </p>

--- a/views/partials/footer.hbs
+++ b/views/partials/footer.hbs
@@ -8,8 +8,8 @@
   <p>
     <span class="pull-left">© <a href="http://timeoff.management">TimeOff.management</a> 2014-2019</span>
     <span class="pull-right">
-      <a href="//github.com/timeoff-management/application"><i class="fa fa-github fa-lg"></i></a>
-      <a href="//twitter.com/FreeTimeOffApp"><i class="fa fa-twitter fa-lg"></i></a>
+      <a href="//github.com/timeoff-management/application" target="_blank"><i class="fa fa-github fa-lg"></i></a>
+      <a href="//twitter.com/FreeTimeOffApp" target="_blank"><i class="fa fa-twitter fa-lg"></i></a>
       <a href="mailto:pavlo@timeoff.management"><i class="fa fa-envelope fa-lg"></i></a>
     </span>
   </p>


### PR DESCRIPTION
Under some circumstances, for example when hosted using IIS and a reverse proxy, the existing links get the current base url prepended, rendering them invalid. This forces absolute urls to be used, guaranteeing they work.

This PR also sets the links to open in a new tab, rather than taking users away from the application as is currently the case.