### PR TITLE
WP: Ability set holiday year start date

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -271,10 +271,9 @@ Email.prototype.promise_leave_request_emails = function(args){
     })
     .then(() => leave.get('user').record_email_addressed_to_me(email_obj))
   );
-
   return Promise.all([
       getCommentsForLeave({leave}),
-      leave.get('user').promise_allowance(),
+      leave.get('user').promise_allowance({month:args.month}),
     ])
     .then(([comments, requesterAllowance]) => bluebird.join(
       promise_email_to_requestor({comments, requesterAllowance}),

--- a/lib/model/Report.js
+++ b/lib/model/Report.js
@@ -23,7 +23,7 @@ const getUsersWithLeaves = ({
     result = result.then(users => Promise.resolve(users.filter(u => String(u.DepartmentId) === String(departmentId))));
   }
 
-  result = result.then(users => Promise.map(users, user => user.reload_with_leave_details({}), { concurrency : 10}));
+  result = result.then(users => Promise.map(users, user => user.reload_with_leave_details({month:company.holiday_year_start_month}), { concurrency : 10}));
 
   const filter = filterLeaves({startDate, endDate});
 

--- a/lib/model/calculateCarryOverAllowance.js
+++ b/lib/model/calculateCarryOverAllowance.js
@@ -17,10 +17,14 @@ const calculateCarryOverAllowance = ({users}) => {
     users,
     user => {
       let carryOver;
-      return Promise.resolve(user.getCompany().then(c => carryOver = c.carry_over))
-        .then(() => user.reload_with_leave_details({year:moment.utc(yearFrom, 'YYYY')}))
+      let holidayMonthStart;
+      return Promise.resolve(user.getCompany().then(c => {
+        carryOver = c.carry_over;
+        holidayMonthStart = c.holiday_year_start_month}))
+        .then(() => user.reload_with_leave_details({month:holidayMonthStart, year:moment.utc(yearFrom, 'YYYY')}))
         .then(user => user.promise_allowance({
           year: moment.utc(yearFrom, 'YYYY'),
+          month: holidayMonthStart,
           now: moment.utc(yearFrom, 'YYYY').endOf('year'),
           forceNow: true,
         }))
@@ -33,6 +37,7 @@ const calculateCarryOverAllowance = ({users}) => {
           return user.promise_to_update_carried_over_allowance({
             carried_over_allowance,
             year: yearTo,
+            month: holidayMonthStart
           });
         })
         .then(() => console.log(`Carried over unused allowance ${yearFrom} -> ${yearTo} for user ${user.id}`));

--- a/lib/model/db/company.js
+++ b/lib/model/db/company.js
@@ -105,6 +105,12 @@ module.exports = function(sequelize, DataTypes) {
       defaultValue : 0,
       comment      : "Defines how may remaining days from allowance are carried over to the next year.",
     },
+    holiday_year_start_month:{
+      type         : DataTypes.INTEGER,
+      allowNull    : true,
+      defaultValue : '01',
+      comment      : "Defines when the holiday month starts for employee's",
+    }
   }, {
 
     indexes : [
@@ -242,7 +248,8 @@ module.exports = function(sequelize, DataTypes) {
       // Create new company based on default values
       create_default_company : function(args){
         var country_code = args.country_code || 'UK',
-          timezone = args.timezone || 'Europe/London';
+          timezone = args.timezone || 'Europe/London',
+          holiday_year_start_month = args.holiday_year_start_month;
 
         // Add new company record
         return Company.create({
@@ -250,6 +257,7 @@ module.exports = function(sequelize, DataTypes) {
             country           : country_code,
             start_of_new_year : 1,
             timezone          : timezone,
+            holiday_year_start_month  : holiday_year_start_month
         })
 
         // When new company is created - add default departments to it

--- a/lib/model/db/department.js
+++ b/lib/model/db/department.js
@@ -6,6 +6,7 @@ const
   Promise = require('bluebird'),
   Exception = require('../../error'),
   CalendarMonth = require('../calendar_month');
+const company = require('./company');
 
 module.exports = function(sequelize, DataTypes) {
   let Department = sequelize.define("Department", {
@@ -119,19 +120,26 @@ module.exports = function(sequelize, DataTypes) {
             self       = this,
             model      = sequelize.models,
             start_date = args.start_date,
-            end_date   = args.end_date;
+            end_date   = args.end_date,
+            company;
 
 
           var promise_users_and_leaves = Promise
 
           // First of all ensure that "start_date" is defined
           .try(function(){
-            if ( start_date ) {
-              return Promise.resolve(start_date);
-            }
-
             return self.getCompany()
-              .then(company => Promise.resolve( start_date = company.get_today() ) )
+            .then(comp => {
+              company = comp
+              if ( start_date ) {
+                return Promise.resolve(start_date);
+              }
+              Promise.resolve( start_date = company.get_today() )
+            })
+
+  
+
+
           })
 
           // Ensure end_date is suitable if it was provided
@@ -175,6 +183,7 @@ module.exports = function(sequelize, DataTypes) {
                 function(user){
                   return user.promise_my_leaves_for_calendar({
                     year : start_date,
+                    month : company.holiday_year_start_month // todo:fix
                   })
                   .then(function(leaves){
 

--- a/lib/model/db/leave.js
+++ b/lib/model/db/leave.js
@@ -244,7 +244,8 @@ get_deducted_days : function(args) {
   var leave_days = [],
     ignore_allowance = false,
     leave_type = this.leave_type || args.leave_type,
-    year;
+    year,
+    month;
 
   if (args && args.hasOwnProperty('ignore_allowance')) {
     ignore_allowance = args.ignore_allowance;
@@ -252,6 +253,9 @@ get_deducted_days : function(args) {
 
   if (args && args.hasOwnProperty('year')) {
     year = moment.utc(args.year, 'YYYY');
+  }
+  if (args && args.hasOwnProperty('month')) {
+    month = moment.utc(args.month, 'MM');
   }
 
   // If current Leave stands for type that does not use
@@ -278,9 +282,15 @@ get_deducted_days : function(args) {
       if ( bank_holiday_map[ leave_day.get_pretty_date() ] ) return;
 
       // If it happenned that current leave day is from the year current
-      // call was made of, ignore that day
-      if (year && year.year() !== moment.utc(leave_day.date).year()) return;
-
+      // call was made of, ignore that day      
+      if (year && month){
+        if(moment.utc(leave_day.date).year() <= year.year()-1 &&moment.utc(leave_day.date).month() <=  month.month() ){
+          return;
+        }
+        if(moment.utc(leave_day.date).year() === year.year()  && moment.utc(leave_day.date).month() >month.month()){
+          return;
+        }
+      }
       // Ignore non-working days (weekends)
       if ( ! schedule.is_it_working_day({ day : moment.utc(leave_day.date) }) ){
         return;

--- a/lib/model/db/user.js
+++ b/lib/model/db/user.js
@@ -487,6 +487,7 @@ function get_class_methods(sequelize) {
           new_user,
           country_code = attributes.country_code,
           timezone     = attributes.timezone,
+          holiday_year_start_month     = attributes.holiday_year_start_month,
           company_name = attributes.company_name;
 
       delete attributes.company_name;
@@ -511,6 +512,7 @@ function get_class_methods(sequelize) {
               name         : company_name,
               country_code : country_code,
               timezone     : timezone,
+              holiday_year_start_month : holiday_year_start_month,
             });
         })
 

--- a/lib/model/leave/index.js
+++ b/lib/model/leave/index.js
@@ -80,6 +80,7 @@ function createNewLeave(args){
     .then(leave_to_create => employee
       .validate_leave_fits_into_remaining_allowance({
         year       : start_date,
+        month      : employee.company.holiday_year_start_month,
         leave_type : leave_type,
         leave      : leave_to_create,
       })

--- a/lib/model/leave_collection.js
+++ b/lib/model/leave_collection.js
@@ -7,7 +7,7 @@ var
   _       = require('underscore'),
   config  = require('../config');
 
-function promise_to_group_leaves(leaves) {
+function promise_to_group_leaves(leaves,holidayMonthStart) {
 
   if ( ! leaves ) {
     throw new Error('Did not get "leaves" in promise_to_group_leaves');
@@ -18,6 +18,9 @@ function promise_to_group_leaves(leaves) {
   // Group leaves by years
   leaves.forEach(leave => {
     let year = moment.utc(leave.get_start_leave_day().date).format('YYYY');
+    if(moment.utc(leave.get_start_leave_day().date).format('M') <= holidayMonthStart){
+      year--;
+    }
 
     if ( ! grouped_leaves[year]) {
       grouped_leaves[ year ] = {

--- a/lib/model/mixin/user/absence_aware.js
+++ b/lib/model/mixin/user/absence_aware.js
@@ -20,11 +20,18 @@ module.exports = function(sequelize){
     var
       self           = this,
       year           = args.year,
+      starting_month = args.starting_month+1,
       show_full_year = args.show_full_year;
 
+    let months =  [1,2,3,4,5,6,7,8,9,10,11,12];
+    let orderMonths =  [...months.slice(months.indexOf(starting_month)), ...months.slice(0, months.indexOf(starting_month))]
+
     if (show_full_year) {
-      return _.map([1,2,3,4,5,6,7,8,9,10,11,12], function(i){
-        return moment.utc(year.format('YYYY')+'-'+i+'-01');
+      return _.map(orderMonths, function(i){
+        var calYear = year.format('YYYY');
+         var holYear = moment(calYear).subtract(i>=starting_month, 'year');
+        
+        return moment.utc(holYear.format('YYYY')+'-'+i+'-01');
       });
     }
 
@@ -40,12 +47,14 @@ module.exports = function(sequelize){
       year           = args.year || this_user.company.get_today(),
       show_full_year = args.show_full_year || false,
       model          = sequelize.models,
+      month          = args.month || 0,
       // Find out if we need to show multi year calendar
       is_multi_year = this_user.company.get_today().month() > 8;
 
     var months_to_show = this_user._get_calendar_months_to_show({
       year           : year.clone(),
-      show_full_year : show_full_year
+      show_full_year : show_full_year,
+      starting_month : month
     });
 
     return Promise.join(
@@ -66,18 +75,15 @@ module.exports = function(sequelize){
             $or : {
               date_start : {
                 $between : [
-                  moment.utc(year).startOf('year').format('YYYY-MM-DD'),
-                  moment.utc(
-                    year.clone().add((is_multi_year ? 1 : 0), 'years')
-                  ).endOf('year').format('YYYY-MM-DD HH:mm'),
+                  moment.utc(year).subtract(1, "year").month(args.month).startOf('month').format('YYYY-MM-DD'),
+                  moment.utc(year).month(args.month-1).endOf('month').format('YYYY-MM-DD HH:mm'),
                 ]
               },
               date_end : {
                 $between : [
-                  moment.utc( year ).startOf('year').format('YYYY-MM-DD'),
-                  moment.utc(
-                    year.clone().add((is_multi_year ? 1 : 0), 'years')
-                  ).endOf('year').format('YYYY-MM-DD HH:mm'),
+                  moment.utc(year).subtract(1, "year").month(args.month).startOf('month').format('YYYY-MM-DD'),
+                  moment.utc(year).month(args.month-1).endOf('month').format('YYYY-MM-DD HH:mm'),
+
                 ]
               }
             }
@@ -186,14 +192,14 @@ module.exports = function(sequelize){
       where_clause['$or'] = {
         date_start : {
           $between : [
-            moment.utc(year).startOf('year').format('YYYY-MM-DD'),
-            moment.utc(year).endOf('year').format('YYYY-MM-DD HH:mm'),
+            moment.utc(year).subtract(1, "year").month(args.month).startOf('month').format('YYYY-MM-DD'),
+            moment.utc(year).month(args.month-1).endOf('month').format('YYYY-MM-DD HH:mm'),
           ]
         },
         date_end : {
           $between : [
-            moment.utc(year).startOf('year').format('YYYY-MM-DD'),
-            moment.utc(year).endOf('year').format('YYYY-MM-DD HH:mm'),
+            moment.utc(year).subtract(1, "year").month(args.month).startOf('month').format('YYYY-MM-DD'),
+            moment.utc(year).month(args.month-1).endOf('month').format('YYYY-MM-DD HH:mm'),
           ]
         }
       };
@@ -248,9 +254,11 @@ module.exports = function(sequelize){
 
   this.promise_my_active_leaves = function(args) {
     var year = args.year || moment.utc();
+    var month = args.month;
 
     return this.promise_my_leaves({
       year          : year,
+      month          : month,
       filter_status : [
         sequelize.models.Leave.status_approved(),
         sequelize.models.Leave.status_new(),
@@ -265,6 +273,7 @@ module.exports = function(sequelize){
 
     return this.promise_my_leaves({
       ignore_year : true,
+      month: this.company.holiday_year_start_month,
       filter_status : [
         sequelize.models.Leave.status_approved(),
         sequelize.models.Leave.status_new(),
@@ -361,9 +370,13 @@ module.exports = function(sequelize){
       _.map(
         _.filter(
           leaves_to_traverse,
-          function (leave){ return leave.is_approved_leave(); }
+          function (leave){ 
+            return leave.is_approved_leave();
+          }
         ),
-        function(leave){ return leave.get_deducted_days_number(args); }
+        function(leave){ 
+          return leave.get_deducted_days_number(args);
+        }
       ),
       function(memo, num){ return memo + num },
       0
@@ -430,7 +443,7 @@ module.exports = function(sequelize){
   },
 
 
-  this.promise_adjustment_and_carry_over_for_year = function(year){
+  this.promise_adjustment_and_carry_over_for_year = function(month,year){
     let self = this;
 
     year = year || moment.utc();
@@ -457,19 +470,19 @@ module.exports = function(sequelize){
       });
   };
 
-  this.promise_adjustmet_for_year = function(year){
+  this.promise_adjustmet_for_year = function(month,year){
     let self = this;
 
     return self
-      .promise_adjustment_and_carry_over_for_year(year)
+      .promise_adjustment_and_carry_over_for_year(month,year)
       .then(combined_record => Promise.resolve(combined_record.adjustment));
   };
 
-  this.promise_carried_over_allowance_for_year = function(year){
+  this.promise_carried_over_allowance_for_year = function(month,year){
     let self = this;
 
     return self
-      .promise_adjustment_and_carry_over_for_year(year)
+      .promise_adjustment_and_carry_over_for_year(month,year)
       .then(combined_record => Promise.resolve(combined_record.carried_over_allowance));
   };
 
@@ -542,14 +555,14 @@ module.exports = function(sequelize){
         $or : {
           date_start : {
             $between : [
-              moment.utc(year).startOf('year').format('YYYY-MM-DD'),
-              moment.utc(year).endOf('year').format('YYYY-MM-DD HH:mm'),
+              moment.utc(year).subtract(1, "year").month(args.month).startOf('month').format('YYYY-MM-DD'),
+              moment.utc(year).month(args.month).endOf('month').format('YYYY-MM-DD HH:mm'),
             ]
           },
           date_end : {
             $between : [
-              moment.utc(year).startOf('year').format('YYYY-MM-DD'),
-              moment.utc(year).endOf('year').format('YYYY-MM-DD HH:mm'),
+              moment.utc(year).subtract(1, "year").month(args.month).startOf('month').format('YYYY-MM-DD'),
+              moment.utc(year).month(args.month).endOf('month').format('YYYY-MM-DD HH:mm'),
             ]
           }
         }
@@ -568,10 +581,12 @@ module.exports = function(sequelize){
     leave_type = args.leave_type,
     leave      = args.leave,
     // Derive year from Leave object
-    year       = args.year || moment.utc(leave.date_start);
+    year       = args.year || moment.utc(leave.date_start),
+    month      = args.month ;
 
     // Make sure object contain all necessary data for that check
     return self.reload_with_leave_details({
+      month: self.company.holiday_year_start_month,
       year : year.clone(),
     })
     .then( employee => employee.reload_with_session_details() )
@@ -579,7 +594,7 @@ module.exports = function(sequelize){
       .then(() => Promise.resolve(employee))
     )
     .then(employee =>
-      employee.promise_allowance({year})
+      employee.promise_allowance({year,month})
       .then(allowance_obj => Promise.resolve([allowance_obj.number_of_days_available_in_allowance, employee]))
     )
     .then(function(args){
@@ -589,6 +604,7 @@ module.exports = function(sequelize){
       let deducted_days =  leave.get_deducted_days_number({
           year       : year.format('YYYY'),
           user       : employee,
+          month      : month,
           leave_type : leave_type,
         });
 

--- a/lib/model/mixin/user/company_aware.js
+++ b/lib/model/mixin/user/company_aware.js
@@ -28,7 +28,9 @@ module.exports = function(sequelize){
   this.get_company_for_user_details = function(args){
     var user_id    = args.user_id,
       year         = args.year || moment.utc(),
-      current_user = this;
+      current_user = this,
+      startingMonth = current_user.company.holiday_year_start_month;
+      ;
 
     return this.getCompany({
       include : [
@@ -48,14 +50,14 @@ module.exports = function(sequelize){
                 $or : {
                   date_start : {
                     $between : [
-                      moment.utc().startOf('year').format('YYYY-MM-DD'),
-                      moment.utc().endOf('year').format('YYYY-MM-DD HH:mm'),
+                      moment.utc().subtract(1, "year").month(startingMonth).startOf('month').format('YYYY-MM-DD'),
+                      moment.utc().month(startingMonth-1).endOf('month').format('YYYY-MM-DD HH:mm'),
                     ]
                   },
                   date_end : {
                     $between : [
-                      moment.utc().startOf('year').format('YYYY-MM-DD'),
-                      moment.utc().endOf('year').format('YYYY-MM-DD HH:mm'),
+                      moment.utc().subtract(1, "year").month(startingMonth).startOf('month').format('YYYY-MM-DD'),
+                      moment.utc().month(startingMonth-1).endOf('month').format('YYYY-MM-DD HH:mm'),
                     ]
                   }
                 }

--- a/lib/model/user_allowance.js
+++ b/lib/model/user_allowance.js
@@ -25,6 +25,10 @@ const
     .object()
     .required(),
 
+  schema_month = Joi
+    .object()
+    .default(() => 0, 'Default month is Jan'),
+
   schema_year = Joi
     .object()
     .type(moment)
@@ -45,6 +49,7 @@ const
     year : schema_year,
     user : schema_user,
     now  : schema_now,
+    month: Joi.number().default(-1),
     /**
      * If TRUE now is not going to be changed.
      */
@@ -208,6 +213,8 @@ class UserAllowance {
    *  all info required for allowance calculation for given user and year.
    * */
   static promise_allowance(args) {
+    
+ 
 
     args = Joi.attempt(
       args,
@@ -217,21 +224,26 @@ class UserAllowance {
 
     let
       user = args.user,
+      month = args.month,
       year = args.year,
       number_of_days_taken_from_allowance,
       manual_adjustment,
       carried_over_allowance;
+
+    if(month === -1){
+      month = user.company.holiday_year_start_month;
+    }
 
     const {forceNow, now} = args;
 
     let flow = Promise.resolve();
 
     if ( user.my_leaves === undefined ) {
-      flow = flow.then(() => user.reload_with_leave_details({year}));
+      flow = flow.then(() => user.reload_with_leave_details({month,year}));
     }
 
     // Fetch adjustment and Carry over allowance
-    flow = flow.then(() => user.promise_adjustment_and_carry_over_for_year(year));
+    flow = flow.then(() => user.promise_adjustment_and_carry_over_for_year(month,year));
 
     flow = flow.then(adjustment_and_coa => {
       manual_adjustment      = adjustment_and_coa.adjustment;
@@ -240,7 +252,7 @@ class UserAllowance {
     });
 
     flow = flow.then(() => Promise.resolve(
-      number_of_days_taken_from_allowance = user.calculate_number_of_days_taken_from_allowance({year : year.format('YYYY')})
+      number_of_days_taken_from_allowance = user.calculate_number_of_days_taken_from_allowance({month:month,year : year.format('YYYY')})
     ));
 
 

--- a/lib/route/calendar.js
+++ b/lib/route/calendar.js
@@ -14,12 +14,13 @@ var express   = require('express'),
 
 router.post('/bookleave/', function(req, res){
 
+  let companyHold;
     Promise.join (
       req.user.promise_users_I_can_manage(),
       req.user.get_company_with_all_leave_types(),
       Promise.try( () => get_and_validate_leave_params({req})),
       (users, company, valide_attributes) => {
-
+companyHold = company;
         // Make sure that indexes submitted map to existing objects
         var employee = users[valide_attributes.user] || req.user,
           leave_type = company.leave_types[valide_attributes.leave_type];
@@ -50,7 +51,7 @@ router.post('/bookleave/', function(req, res){
       }
     )
     .then(leave => leave.reloadWithAssociates())
-    .then(leave => (new EmailTransport()).promise_leave_request_emails({leave}))
+    .then(leave => (new EmailTransport()).promise_leave_request_emails({leave,month:companyHold.holiday_year_start_month}))
     .then(function(){
 
         req.session.flash_message('New leave request was added');
@@ -91,10 +92,11 @@ router.get('/', function(req, res) {
   Promise.join(
     req.user.promise_calendar({
       year           : current_year.clone(),
+      month:req.user.company.holiday_year_start_month,
       show_full_year : show_full_year,
     }),
     req.user.get_company_with_all_leave_types(),
-    req.user.reload_with_leave_details({ year : current_year }),
+    req.user.reload_with_leave_details({ month:req.user.company.holiday_year_start_month, year : current_year }),
     req.user.promise_supervisors(),
     req.user.promise_allowance({ year : current_year }),
     function(calendar, company, user, supervisors, user_allowance){

--- a/lib/route/login.js
+++ b/lib/route/login.js
@@ -88,6 +88,7 @@ module.exports = function(passport) {
         url_to_the_site_root : get_url_to_site_root_for_anonymous_session(req),
         countries            : config.get('countries'),
         timezones_available  : moment_tz.tz.names(),
+        months_available     : moment_tz.monthsShort(),
       });
   });
 
@@ -136,7 +137,10 @@ module.exports = function(passport) {
       let timezone = validator.trim(req.body['timezone']);
       if ( ! moment_tz.tz.names().find(tz_str => tz_str === timezone) ) {
         req.session.flash_error('Time zone is unknown');
-      }
+      }     
+      
+      var holiday_year_start_month = moment_tz.monthsShort().indexOf(req.body['holiday_year_start']);
+   
 
       // In case of validation error redirect back to registration form
       if ( req.session.flash_has_errors() ) {
@@ -145,14 +149,15 @@ module.exports = function(passport) {
 
       // Try to create new record of user
       req.app.get('db_model').User.register_new_admin_user({
-          email        : email.toLowerCase(),
-          password     : password,
-          name         : name,
-          lastname     : lastname,
-          company_name : company_name,
-          country_code : country_code,
-          timezone     : timezone,
-      })
+          email              : email.toLowerCase(),
+          password           : password,
+          name               : name,
+          lastname           : lastname,
+          company_name       : company_name,
+          country_code       : country_code,
+          timezone           : timezone,
+          holiday_year_start_month : holiday_year_start_month,
+        })
       // Send registration email
       .then(function(user){
         var email = new EmailTransport();

--- a/lib/route/requests.js
+++ b/lib/route/requests.js
@@ -11,10 +11,12 @@ var express   = require('express'),
 
 router.get('/', function(req, res){
 
+
+
     Promise.join(
         req.user
           .promise_my_active_leaves_ever()
-          .then(leaves => LeaveCollectionUtil.promise_to_group_leaves(leaves)),
+          .then(leaves => LeaveCollectionUtil.promise_to_group_leaves(leaves,req.user.company.holiday_year_start_month)),
         req.user.promise_leaves_to_be_processed(),
         function(my_leaves_grouped, to_be_approved_leaves){
 

--- a/lib/route/settings.js
+++ b/lib/route/settings.js
@@ -56,6 +56,7 @@ router.get('/general/', function(req, res){
       company   : company,
       schedule  : schedule,
       countries : config.get('countries'),
+      months_available     : moment_tz.monthsShort(),
       timezones_available : moment_tz.tz.names(),
       carryOverOptions : getAvailableCarriedOverOptions(),
       yearCurrent: moment.utc().year(),
@@ -96,6 +97,8 @@ router.post('/company/', function(req, res){
     return res.redirect_with_session('/settings/general/');
   }
 
+  var holiday_year_start_month = moment_tz.monthsShort().indexOf(req.body['holiday_year_start']);
+
   req.user.getCompany()
 
   // Validate provided date format
@@ -118,6 +121,8 @@ router.post('/company/', function(req, res){
     company.timezone          = timezone;
     company.carry_over        = carriedOverDays;
     company.is_team_view_hidden = isTeamViewHidden;
+    company.holiday_year_start_month = holiday_year_start_month;
+
 
     return company.save();
   })

--- a/lib/route/users/index.js
+++ b/lib/route/users/index.js
@@ -253,17 +253,18 @@ router.get('/edit/:user_id/', function(req, res){
 router.get('/edit/:user_id/absences/', function(req, res){
   let
     user_id = validator.trim(req.params['user_id']),
-    user_allowance;
-
+    user_allowance,
+    holidayMonthStart; 
   Promise
 
   .try( () => ensure_user_id_is_integer({req : req, user_id : user_id}) )
   .then(() => req.user.get_company_for_user_details({ user_id : user_id }) )
   .then(function(company){
     let employee = company.users[0];
+    holidayMonthStart = company.holiday_year_start_month
     return employee.reload_with_session_details();
   })
-  .then( employee => employee.reload_with_leave_details({}))
+  .then( employee => employee.reload_with_leave_details({month:holidayMonthStart}))
   .then(employee => Promise.join(
 
     employee
@@ -271,10 +272,10 @@ router.get('/edit/:user_id/absences/', function(req, res){
       .then( allowance_obj => Promise.resolve([user_allowance = allowance_obj, employee]) ),
 
     employee
-      .promise_adjustmet_for_year(moment.utc().format('YYYY')),
+      .promise_adjustmet_for_year(holidayMonthStart,moment.utc().format('YYYY')),
 
     employee
-      .promise_carried_over_allowance_for_year(moment.utc().format('YYYY')),
+      .promise_carried_over_allowance_for_year(holidayMonthStart,moment.utc().format('YYYY')),
 
     (args, employee_adjustment, carried_over_allowance) => {
       args.push(null);
@@ -313,7 +314,7 @@ router.get('/edit/:user_id/absences/', function(req, res){
       .then(function(){
         employee
           .promise_my_active_leaves_ever({})
-          .then(leaves => LeaveCollectionUtil.promise_to_group_leaves(leaves))
+          .then(leaves => LeaveCollectionUtil.promise_to_group_leaves(leaves,employee.company.holiday_year_start_month))
           .then(function(grouped_leaves){
 
             res.render('user_details', {
@@ -398,12 +399,13 @@ router.get('/edit/:user_id/calendar/', async (req, res) => {
 
     calendar = await employee.promise_calendar({
       year: year.clone(),
+      month: company.holiday_year_start_month,
       show_full_year: true,
     });
     companyEnriched = await employee.get_company_with_all_leave_types();
-    employee = await employee.reload_with_leave_details({ year });
+    employee = await employee.reload_with_leave_details({month: company.holiday_year_start_month, year });
     supervisors = await employee.promise_supervisors();
-    userAllowance = await employee.promise_allowance({ year });
+    userAllowance = await employee.promise_allowance({month: company.holiday_year_start_month, year });
 
   } catch (error) {
 
@@ -731,7 +733,8 @@ router.get('/', function(req, res) {
 
     var department_id = req.query['department'],
         users_filter = {},
-        model = req.app.get('db_model');
+        model = req.app.get('db_model'),
+        startingMonth = req.user.company.holiday_year_start_month;
 
     if (validator.isNumeric( department_id )) {
       users_filter = { DepartmentId : department_id };
@@ -764,14 +767,14 @@ router.get('/', function(req, res) {
                 $or : {
                   date_start : {
                     $between : [
-                      moment.utc().startOf('year').format('YYYY-MM-DD'),
-                      moment.utc().endOf('year').format('YYYY-MM-DD HH:mm'),
+                      moment.utc().subtract(1, "year").month(startingMonth).startOf('month').format('YYYY-MM-DD'),
+                      moment.utc().month(startingMonth-1).endOf('month').format('YYYY-MM-DD HH:mm'),
                     ]
                   },
                   date_end : {
                     $between : [
-                      moment.utc().startOf('year').format('YYYY-MM-DD'),
-                      moment.utc().endOf('year').format('YYYY-MM-DD HH:mm'),
+                      moment.utc().subtract(1, "year").month(startingMonth).startOf('month').format('YYYY-MM-DD'),
+                      moment.utc().month(startingMonth-1).endOf('month').format('YYYY-MM-DD HH:mm'),
                     ]
                   }
                 }

--- a/migrations/20201123-company-start-date.js
+++ b/migrations/20201123-company-start-date.js
@@ -1,0 +1,25 @@
+
+'use strict';
+
+var models = require('../lib/model/db');
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+
+    queryInterface.describeTable('Companies').then(attributes => {
+
+      if (attributes.hasOwnProperty('holiday_year_start_date')) {
+        return 1;
+      }
+
+      return queryInterface.addColumn(
+        'Companies',
+        'holiday_year_start_date-date',
+        models.Company.attributes.holiday_year_start_date
+      );
+    });
+  },
+
+  down: (queryInterface, Sequelize) => queryInterface
+    .removeColumn('Companies', 'holiday_year_start_date'),
+};

--- a/views/general_settings.hbs
+++ b/views/general_settings.hbs
@@ -62,6 +62,16 @@
                 </div>
               </div>
 
+              <div class="form-group">
+               <label for="input_time_zone" class="col-md-4 control-label">Holiday year start</label>
+                <div class="col-md-8">
+                  <select class="form-control" id="holiday_year_start_inp" placeholder="Holiday Year Start" name="holiday_year_start">
+                    {{#each months_available}}
+                    <option value="{{this}}" {{# if_equal @key ../company.holiday_year_start_month }} selected="selected"{{/if_equal}}>{{this}}</option>
+                    {{/each}}
+                  </select>
+                </div>
+              </div>
 
               <div class="form-group">
                 <label for="input_carry_over" class="col-md-4 control-label">Carried over days</label>

--- a/views/register.hbs
+++ b/views/register.hbs
@@ -79,6 +79,17 @@
       </div>
 
       <div class="form-group">
+        <label for="holiday_year_start_inp" class="col-md-2 control-label">Holiday year start</label>
+        <div class="col-md-6">
+          <select class="form-control" id="holiday_year_start_inp" placeholder="Holiday Year Start" name="holiday_year_start">
+            {{#each months_available}}
+            <option value="{{this}}" {{#if_equal this 'Jan' }} selected="selected" {{/if_equal}}>{{this}}</option>
+            {{/each}}
+          </select>
+        </div>
+      </div>
+
+      <div class="form-group">
         <div class="col-md-offset-2 col-md-6">
           <button id="submit_registration" type="submit" class="btn btn-success">Create</button>
         </div>


### PR DESCRIPTION
This change allows users on start to set the companys holiday year start (for example April or defaulted to January) with the holiday year running from then (for example 1st April-> 31st March)

We had this problem within our Company and looking though the issues it appears several users had similar request. See #218 , #114 and #354

I has set this to WP as I am never new to this project and believe there will likely be some feedback or changes to make. 