### PR TITLE
Team view page improvements

### DIFF
--- a/lib/route/calendar.js
+++ b/lib/route/calendar.js
@@ -137,7 +137,7 @@ router.get('/teamview/', async (req, res) => {
     ? moment.utc(req.query['date'])
     : user.company.get_today();
 
-  const grouped_mode = !! req.query['grouped_mode'];
+  const grouped_mode = getGroupedModeParameter(req);
 
   const team_view = new TeamView({ user, base_date });
 
@@ -194,6 +194,25 @@ router.get('/teamview/', async (req, res) => {
     return res.redirect_with_session('/');
   };
 });
+
+const getGroupedModeParameter = (req) => {
+  /**
+   * grouped_mode parameter is saved in the current session so user's
+   * transition between different pages does not reset the value
+   */
+  let groupedMode = !! req.query['grouped_mode'];
+
+  if (req.query['save_grouped_mode']) {
+    req.session.teamViewGroupedMode = groupedMode
+  } 
+
+  // for cases when no grouped_mode parameter was supplied: used onf from session
+  if (req.query['grouped_mode'] === undefined) {
+    groupedMode = req.session.teamViewGroupedMode
+  }
+
+  return groupedMode
+};
 
 const groupUsersOnTeamViewByDepartments = (usersAndLeaves) => {
   const departmentsDict = usersAndLeaves.reduce(

--- a/views/partials/team_view_url_parameters.hbs
+++ b/views/partials/team_view_url_parameters.hbs
@@ -1,1 +1,4 @@
-{{#if current_department }}department={{current_department.id}}{{/if}}{{#if base_date }}&date={{ as_date_formatted base_date 'YYYY-MM' }}{{/if}}{{#if grouped_mode}}&grouped_mode={{grouped_mode}}{{/if}}
+{{#if current_department }}{{#unless grouped_mode}}department={{current_department.id}}&{{/unless}}{{/if~}}
+{{~#if base_date }}date={{ as_date_formatted base_date 'YYYY-MM' }}&{{/if~}}
+{{~#if grouped_mode }}grouped_mode={{grouped_mode}}&{{/if~}}
+{{~#if save_grouped_mode}}save_grouped_mode=1&{{/if~}}

--- a/views/team_view.hbs
+++ b/views/team_view.hbs
@@ -8,7 +8,7 @@
   <div class="col-md-3 col-md-offset-3">
     <div class="btn-group btn-group-sm pull-right" role="group">
       <a href="/calendar/teamview/?{{> team_view_url_parameters grouped_mode = 0 }}" class="btn btn-default" {{#unless grouped_mode}}disabled=disabled{{/unless}}>All</a>
-      <a href="/calendar/teamview/?{{> team_view_url_parameters grouped_mode = 1 }}" class="btn btn-default" {{#if grouped_mode}}disabled=disabled{{/if}}>By Department</a>
+      <a href="/calendar/teamview/?{{> team_view_url_parameters grouped_mode = 1 }}" class="btn btn-default" {{#if grouped_mode}}disabled=disabled{{/if}}>By department</a>
     </div>
   </div>
 </div>

--- a/views/team_view.hbs
+++ b/views/team_view.hbs
@@ -7,8 +7,8 @@
   <div class="col-md-6 lead">{{logged_user.name}} {{logged_user.lastname}}'s team <a href="/calendar/feeds/" data-toggle="tooltip" data-placement="right" title="Export Team View to external calendars"><span class="fa fa-rss"></span></a></div>
   <div class="col-md-3 col-md-offset-3">
     <div class="btn-group btn-group-sm pull-right" role="group">
-      <a href="/calendar/teamview/?{{> team_view_url_parameters grouped_mode = 0 }}" class="btn btn-default" {{#unless grouped_mode}}disabled=disabled{{/unless}}>All</a>
-      <a href="/calendar/teamview/?{{> team_view_url_parameters grouped_mode = 1 }}" class="btn btn-default" {{#if grouped_mode}}disabled=disabled{{/if}}>By department</a>
+      <a href="/calendar/teamview/?{{> team_view_url_parameters grouped_mode = 0 save_grouped_mode = 1 }}" class="btn btn-default" {{#unless grouped_mode}}disabled=disabled{{/unless}}>All</a>
+      <a href="/calendar/teamview/?{{> team_view_url_parameters grouped_mode = 1 save_grouped_mode = 1 }}" class="btn btn-default" {{#if grouped_mode}}disabled=disabled{{/if}}>By department</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Few UX improvements for the Team View page

* New labels align in style with existing ones throughout application
* Store newly introduced `grouped_mode` parameter in the session so it is saved between pages
* Fix filtering when `grouped_mode` and `department_id` are selected