### PR TITLE
Respect the date range on the Leaves report

### DIFF
--- a/lib/model/Report.js
+++ b/lib/model/Report.js
@@ -121,16 +121,6 @@ const fetchLeavesForLeavesReport = async ({startDate, endDate, departmentId, lea
       usersLeaves = usersLeaves.filter(l => `${l.leaveTypeId}` === `${leaveTypeId}`);
     }
 
-    if (startDate) {
-      const epoch = startDate.valueOf();
-      usersLeaves = usersLeaves.filter(l => moment.utc(l.date_start).toDate().valueOf() >= epoch);
-    }
-
-    if (endDate) {
-      const epoch = endDate.valueOf();
-      usersLeaves = usersLeaves.filter(l => moment.utc(l.date_end).toDate().valueOf() <= epoch);
-    }
-
     leavesObjects.push(...usersLeaves);
   }
 

--- a/lib/model/mixin/user/absence_aware.js
+++ b/lib/model/mixin/user/absence_aware.js
@@ -216,6 +216,11 @@ module.exports = function(sequelize){
             moment.utc(dateStart).startOf('day').format('YYYY-MM-DD'),
             moment.utc(dateEnd).endOf('day').format('YYYY-MM-DD HH:mm'),
           ]
+        },
+        // Case when given data range is within existing leave
+        $and: {
+          date_start: {$lte: moment.utc(dateStart).startOf('day').format('YYYY-MM-DD')},
+          date_end: {$gte: moment.utc(dateEnd).endOf('day').format('YYYY-MM-DD')},
         }
       };
     }

--- a/views/report/leaves.hbs
+++ b/views/report/leaves.hbs
@@ -54,7 +54,7 @@
           </div>
           <div class="col-md-3">
             <div class="form-group">
-              <label for="leave_type_id">Leave Type</label>
+              <label for="leave_type_id">Leave type</label>
               <select class="form-control" id="leave_type_id" name="leave_type">
                 <option>All</option>
                 {{#each leaveTypes}}


### PR DESCRIPTION
Fix an issue with Leaves report: it should fetch all leaves
that overlap with given the date range. As initially it
rendered only those leaves that start and end within given
date range.