### PR TITLE
minimum changes for docker build to succeed

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "sequelize": "^3.19.2",
     "sequelize-cli": "2.5.1",
     "serve-favicon": "^2.1.7",
-    "sqlite3": "^4.0.1",
+    "sqlite3": "^5.1.6",
     "underscore": "^1.8.3",
     "uuid": "^3.3.2",
     "validator": "^3.43.0"
@@ -46,7 +46,7 @@
   "devDependencies": {
     "chai": "^2.2.0",
     "mocha": "^6.2.2",
-    "node-sass": "^4.5.3",
+    "node-sass": "^8.0.0",
     "request-promise": "^4.2.2",
     "selenium-webdriver": "2.53.3"
   },


### PR DESCRIPTION
No, I don't know exactly what I'm doing or why these versions, in particular, work. But they are sufficient for my build to succeed and nominal running of the image to work. By no means did I exhaustively test the resulting image.

And still many deprecation warnings as well. I also tried some intermediate versions of the two changed modules, and these were the earliest versions where the build succeeded.

Earlier versions did a lot of complaining about:
```
npm ERR! node-pre-gyp http 403 https://mapbox-node-binary.s3.amazonaws.com/...
```